### PR TITLE
Ignore node_modules by default

### DIFF
--- a/lib/git/si.rb
+++ b/lib/git/si.rb
@@ -283,7 +283,7 @@ continue, it's wise to reset the master branch afterward."
           end
 
           # check for existing .gitingore
-          gitignore = [".svn", "*.sw?", ".config", "*.err", "*.pid", "*.log", "svn-commit.*", "*.orig"]
+          gitignore = [".svn", "*.sw?", ".config", "*.err", "*.pid", "*.log", "svn-commit.*", "*.orig", "node_modules"]
           command = "svn status --ignore-externals "
           svn_status = `#{command}`
           raise SvnError.new("Failed to get the svn status. I'm not sure why. Check for any errors above.") if ! $?.success?


### PR DESCRIPTION
Ignore node_modules by default to keep 'em out of the repo.

Ideally I think the code should walk all of the non-external dirs looking for svn:ignore's, but that's pain.