### PR TITLE
Add -r flag to `git rm` command

### DIFF
--- a/lib/git/si/git-control.rb
+++ b/lib/git/si/git-control.rb
@@ -102,7 +102,7 @@ module Git
 
       def self.delete_command(filename)
         raise GitSiError.new("Remove file command requires filename") if filename.empty?
-        "#{@@git_binary} rm #{filename}"
+        "#{@@git_binary} rm -r #{filename}"
       end
 
     end

--- a/spec/git-control_spec.rb
+++ b/spec/git-control_spec.rb
@@ -248,7 +248,7 @@ git-si 0.3.0 svn update to version 1014
     end
 
     it "returns the correct command" do
-      expect(Git::Si::GitControl.delete_command('foobar')).to eq( "git rm foobar" )
+      expect(Git::Si::GitControl.delete_command('foobar')).to eq( "git rm -r foobar" )
     end
   end
 end


### PR DESCRIPTION
Since svn update can produce deleted directories, we need to be able to delete them recursively in git.