### PR TITLE
Add `atune` action to update git repo mirror branch

### DIFF
--- a/lib/git/si.rb
+++ b/lib/git/si.rb
@@ -114,6 +114,15 @@ use the commands below.
       end
 
       ################
+      # Action: atune
+      ################
+      desc "atune", "Commit files to mirror branch that have been modified."
+      def atune
+        configure
+        do_atune_action
+      end
+
+      ################
       # Action: readd
       ################
       desc "readd", "Add files to svn that have been added to git."

--- a/lib/git/si/actions.rb
+++ b/lib/git/si/actions.rb
@@ -150,6 +150,7 @@ module Git
       def do_atune_action
         notice_message "Atuning mirror branch with current svn state"
         on_mirror_branch do
+          add_all_svn_files
           run_command( Git::Si::GitControl.commit_all_command )
         end
       end

--- a/lib/git/si/actions.rb
+++ b/lib/git/si/actions.rb
@@ -147,6 +147,13 @@ module Git
         end
       end
 
+      def do_atune_action
+        notice_message "Atuning mirror branch with current svn state"
+        on_mirror_branch do
+          run_command( Git::Si::GitControl.commit_all_command )
+        end
+      end
+
     end
   end
 end

--- a/lib/git/si/actions.rb
+++ b/lib/git/si/actions.rb
@@ -153,6 +153,9 @@ module Git
           add_all_svn_files
           run_command( Git::Si::GitControl.commit_all_command )
         end
+        on_local_branch do
+          run_command( Git::Si::GitControl.rebase_command( get_mirror_branch ) )
+        end
       end
 
     end

--- a/lib/git/si/git-control.rb
+++ b/lib/git/si/git-control.rb
@@ -45,6 +45,11 @@ module Git
         "#{@@git_binary} commit --allow-empty -am 'git-si #{version} svn update to version #{revision}'"
       end
 
+      def self.commit_all_command
+        version = Git::Si::Version.version
+        "#{@@git_binary} commit --allow-empty -am 'git-si #{version} atuned to current svn state'"
+      end
+
       def self.stash_command
         "#{@@git_binary} stash"
       end

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -153,6 +153,11 @@ M something else"
       expect( subject ).to receive( :on_mirror_branch ).once
       subject.do_atune_action
     end
+
+    it "calls add_all_svn_files" do
+      expect( subject ).to receive( :add_all_svn_files ).once
+      subject.do_atune_action
+    end
   end
 
   describe "#do_fetch_action" do

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -143,6 +143,18 @@ M something else"
     end
   end
 
+  describe "#do_atune_action" do
+    it "calls git commit all" do
+      expect( runner_spy ).to receive( :run_command ).with( /git commit.*-a/, any_args )
+      subject.do_atune_action
+    end
+
+    it "operates in the mirror branch" do
+      expect( subject ).to receive( :on_mirror_branch ).once
+      subject.do_atune_action
+    end
+  end
+
   describe "#do_fetch_action" do
     it "calls stash_local_changes" do
       expect( subject ).to receive( :stash_local_changes ).once

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -158,6 +158,12 @@ M something else"
       expect( subject ).to receive( :add_all_svn_files ).once
       subject.do_atune_action
     end
+
+    it "calls rebase command with the mirror branch" do
+      allow( subject ).to receive( :get_mirror_branch ).and_return( 'testbranch' )
+      expect( runner_spy ).to receive( :run_command ).with( /git rebase .+testbranch/, any_args )
+      subject.do_atune_action
+    end
   end
 
   describe "#do_fetch_action" do

--- a/spec/git-control_spec.rb
+++ b/spec/git-control_spec.rb
@@ -138,6 +138,13 @@ git-si 0.3.0 svn update to version 1014
     end
   end
 
+  describe ".commit_all_command" do
+    it "returns the correct command" do
+      version = Git::Si::Version.version
+      expect( Git::Si::GitControl.commit_all_command ).to eq( "git commit --allow-empty -am 'git-si #{version} atuned to current svn state'" )
+    end
+  end
+
   describe ".stash_command" do
     it "returns the correct command" do
       expect(Git::Si::GitControl.stash_command).to eq( "git stash" )


### PR DESCRIPTION
For when the mirror branch gets out of sync with the svn repo.