### PR TITLE
Allow readd action to remove files from git

### DIFF
--- a/lib/git/si/actions.rb
+++ b/lib/git/si/actions.rb
@@ -53,6 +53,8 @@ module Git
             if yes? "Do you want to add the above files to svn? [y/N] ", :green
               run_command( Git::Si::SvnControl.add_command( files_to_add ) )
               success_message "Added files to svn that had been added to git."
+            elsif yes? "Since you did not add them to svn, do you want to remove the above files from git? [y/N] ", :green
+              run_command( Git::Si::GitControl.remove_command( files_to_add ) )
             end
           end
 
@@ -161,4 +163,3 @@ module Git
     end
   end
 end
-

--- a/lib/git/si/git-control.rb
+++ b/lib/git/si/git-control.rb
@@ -36,6 +36,11 @@ module Git
         "#{@@git_binary} add " + files.join(' ')
       end
 
+      def self.remove_command(*files)
+        raise GitSiError.new("Remove command requires filenames") if ( files.length == 0 )
+        "#{@@git_binary} rm " + files.join(' ')
+      end
+
       def self.are_there_changes?(status_output)
         status_output.match(/^\s*[MADRC]/)
       end
@@ -113,5 +118,3 @@ module Git
     end
   end
 end
-
-

--- a/spec/actions_spec.rb
+++ b/spec/actions_spec.rb
@@ -276,6 +276,18 @@ M something else"
       subject.do_readd_action
     end
 
+    context "when the user declines adding git files unknown to svn" do
+      before do
+        allow( subject ).to receive( :yes? ).and_return( false, true )
+        allow( subject ).to receive( :is_file_in_git? ).and_return( true )
+      end
+
+      it "removes those files from git" do
+        expect( subject ).to receive( :run_command ).with( /git rm.*whatever/, any_args )
+        subject.do_readd_action
+      end
+    end
+
     it "includes the correct files in the svn add command" do
       allow( subject ).to receive( :is_file_in_git? ).and_return( false )
       allow( subject ).to receive( :is_file_in_git? ).with( 'whatever' ).and_return( true )

--- a/spec/git-control_spec.rb
+++ b/spec/git-control_spec.rb
@@ -127,6 +127,16 @@ git-si 0.3.0 svn update to version 1014
     end
   end
 
+  describe ".remove_command" do
+    it "raises an error if no files are specified" do
+      expect { Git::Si::GitControl.remove_command }.to raise_error
+    end
+
+    it "returns the correct command with files" do
+      expect( Git::Si::GitControl.remove_command( "foobar" ) ).to eq( "git rm foobar" )
+    end
+  end
+
   describe ".commit_revision_command" do
     it "raises an error if no version is specified" do
       expect { Git::Si::GitControl.commit_revision_command }.to raise_error


### PR DESCRIPTION
If the files are not present in svn and the user declines to add them, ask if the user wishes to remove them from git.
